### PR TITLE
Fixed plugin dir extraction if return value of rabbitmqctl contains newline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - sudo ln -s /usr/bin/rake2.0 /usr/bin/rake
 
   # Install Ansible through pip
-  - pip install ansible==2.2.1.0
+  - pip install ansible
   - ansible --version
 
   - hostname

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - sudo ln -s /usr/bin/rake2.0 /usr/bin/rake
 
   # Install Ansible through pip
-  - pip install ansible
+  - pip install ansible==2.2.1.0
   - ansible --version
 
   - hostname

--- a/tasks/install_rabbit.yml
+++ b/tasks/install_rabbit.yml
@@ -58,7 +58,7 @@
 
 - name: Get rabbitmq plugins dir
   shell: rabbitmqctl environment | grep -A 1 plugins_dir | grep -oE '"/.+"' | cut -d ':' -f 2 | tr -d '"'
-  register: rabbit_plugins_dir_string
+  register: rabbit_plugins_dir
 
 - name: Output RabbitMQ plugins path
   debug:

--- a/tasks/install_rabbit.yml
+++ b/tasks/install_rabbit.yml
@@ -57,12 +57,8 @@
     state: started
 
 - name: Get rabbitmq plugins dir
-  shell: rabbitmqctl environment | grep -A 1 plugins_dir | grep -oE '"/.+"'
+  shell: rabbitmqctl environment | grep -A 1 plugins_dir | grep -oE '"/.+"' | cut -d ':' -f 2 | tr -d '"'
   register: rabbit_plugins_dir_string
-
-- name: Extract plugins_dir path and keep in variable
-  set_fact:
-    rabbit_plugins_dir: "{{ rabbit_plugins_dir_string.stdout[1:-1] }}"
 
 - name: Output RabbitMQ plugins path
   debug:

--- a/tasks/install_rabbit.yml
+++ b/tasks/install_rabbit.yml
@@ -64,6 +64,11 @@
   debug:
     msg: "{{ rabbit_plugins_dir }}"
 
+- name: Plugins to install debug output
+  debug:
+    msg: "files/{{ item }}.ez -> {{ rabbit_plugins_dir }}"
+  with_items: '{{ rabbitmq_custom_plugins }}'
+
 - name: Place custom plugins into the plugins dir
   copy:
     src: "{{ item }}.ez"

--- a/tasks/install_rabbit.yml
+++ b/tasks/install_rabbit.yml
@@ -57,7 +57,7 @@
     state: started
 
 - name: Get rabbitmq plugins dir
-  shell: rabbitmqctl environment | grep plugins_dir | grep -oE '".+"'
+  shell: rabbitmqctl environment | grep -A 1 plugins_dir | grep -oE '"/.+"'
   register: rabbit_plugins_dir_string
 
 - name: Extract plugins_dir path and keep in variable

--- a/tasks/install_rabbit.yml
+++ b/tasks/install_rabbit.yml
@@ -62,17 +62,17 @@
 
 - name: Output RabbitMQ plugins path
   debug:
-    msg: "{{ rabbit_plugins_dir }}"
+    msg: "{{ rabbit_plugins_dir.stdout }}"
 
 - name: Plugins to install debug output
   debug:
-    msg: "files/{{ item }}.ez -> {{ rabbit_plugins_dir }}"
+    msg: "files/{{ item }}.ez -> {{ rabbit_plugins_dir.stdout }}"
   with_items: '{{ rabbitmq_custom_plugins }}'
 
 - name: Place custom plugins into the plugins dir
   copy:
     src: "{{ item }}.ez"
-    dest: "{{ rabbit_plugins_dir }}"
+    dest: "{{ rabbit_plugins_dir.stdout }}"
   with_items: '{{ rabbitmq_custom_plugins }}'
 
 - name: Stop rabbitmq-server to add config file


### PR DESCRIPTION
when output look like:
```
{plugins_dir,
          "/usr/lib/rabbitmq/plugins:/usr/lib/rabbitmq/lib/rabbitmq_server-3.6.9/plugins"},
```

Instead of:
`{plugins_dir, "/usr/lib/rabbitmq/plugins:/usr/lib/rabbitmq/lib/rabbitmq_server-3.6.9/plugins"},`